### PR TITLE
Add a config setting for custom behaviour, defaulting to false when running the migration.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,24 +52,23 @@ func Write(config structs.Config, configPath string) (err error) {
 }
 
 func Migrate(configPath string) error {
-    originalConfig, err := Read(configPath)
-    if err != nil {
-        return err 
-    }
+	originalConfig, err := Read(configPath)
+	if err != nil {
+		return err
+	}
 
+	var newConfig = &structs.Config{
+		EditorCmd:       originalConfig.EditorCmd,
+		CustomBehaviour: false,
+		DirAliases:      originalConfig.DirAliases,
+	}
 
-    var newConfig = &structs.Config{
-        EditorCmd: originalConfig.EditorCmd,
-        CustomBehaviour: false,
-        DirAliases: originalConfig.DirAliases,
-    }
+	err = Write(*newConfig, configPath)
+	if err != nil {
+		return err
+	}
 
-    err = Write(*newConfig, configPath)
-    if err != nil {
-        return err
-    }
-
-    return nil
+	return nil
 }
 
 // Read reads the configPath file and returns a Config struct

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,15 +40,36 @@ func Init(configDir string, configPath string) (err error) {
 func Write(config structs.Config, configPath string) (err error) {
 	jsonFile, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return
+		return err
 	}
 
 	err = os.WriteFile(configPath, jsonFile, 0644)
 	if err != nil {
-		return
+		return err
 	}
 
-	return
+	return nil
+}
+
+func Migrate(configPath string) error {
+    originalConfig, err := Read(configPath)
+    if err != nil {
+        return err 
+    }
+
+
+    var newConfig = &structs.Config{
+        EditorCmd: originalConfig.EditorCmd,
+        CustomBehaviour: false,
+        DirAliases: originalConfig.DirAliases,
+    }
+
+    err = Write(*newConfig, configPath)
+    if err != nil {
+        return err
+    }
+
+    return nil
 }
 
 // Read reads the configPath file and returns a Config struct

--- a/internal/gopen/gopen.go
+++ b/internal/gopen/gopen.go
@@ -21,25 +21,31 @@ func Gopen(targetAlias string, config structs.Config) (err error) {
 		}
 	}
 
-	if targetPath == "" {
-		return errors.New("Invalid command or non-existent alias\nRun `gopen help` for info")
-	}
+    if targetPath == "" {
+        return errors.New("Invalid command or non-existent alias\nRun `gopen help` for info")
+    }
+    var cmd *exec.Cmd
+    editorCmd := config.EditorCmd
+    err = os.Chdir(targetPath)
+    if err != nil {
+        return
+    }
+    // Custom editor allows for the use of non-terminal based editors
+    // that need the path to the project as an argument
+    if config.CustomBehaviour {
+        cmd = exec.Command(editorCmd, targetPath)
+    } else {
+        cmd = exec.Command(editorCmd)
+    }
 
-	editorCmd := config.EditorCmd
-	err = os.Chdir(targetPath)
-	if err != nil {
-		return
-	}
+cmd.Stdin = os.Stdin
+cmd.Stdout = os.Stdout
+cmd.Stderr = os.Stderr
 
-	cmd := exec.Command(editorCmd)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+err = cmd.Run()
+if err != nil {
+    return
+}
 
-	err = cmd.Run()
-	if err != nil {
-		return
-	}
-
-	return
+return
 }

--- a/internal/gopen/gopen.go
+++ b/internal/gopen/gopen.go
@@ -2,24 +2,24 @@
 package gopen
 
 import (
-	"errors"
-	"os"
-	"os/exec"
+    "errors"
+    "os"
+    "os/exec"
 
-	"github.com/wipdev-tech/gopen/internal/structs"
+    "github.com/wipdev-tech/gopen/internal/structs"
 )
 
 // Gopen uses the Config struct to find the path corresponding to targetAlias
 // and executes the editor command with the target path as the working
 // directory
 func Gopen(targetAlias string, config structs.Config) (err error) {
-	var targetPath string
-	for _, dirAlias := range config.DirAliases {
-		if targetAlias == dirAlias.Alias {
-			targetPath = dirAlias.Path
-			break
-		}
-	}
+    var targetPath string
+    for _, dirAlias := range config.DirAliases {
+        if targetAlias == dirAlias.Alias {
+            targetPath = dirAlias.Path
+            break
+        }
+    }
 
     if targetPath == "" {
         return errors.New("Invalid command or non-existent alias\nRun `gopen help` for info")
@@ -38,14 +38,14 @@ func Gopen(targetAlias string, config structs.Config) (err error) {
         cmd = exec.Command(editorCmd)
     }
 
-cmd.Stdin = os.Stdin
-cmd.Stdout = os.Stdout
-cmd.Stderr = os.Stderr
+    cmd.Stdin = os.Stdin
+    cmd.Stdout = os.Stdout
+    cmd.Stderr = os.Stderr
 
-err = cmd.Run()
-if err != nil {
+    err = cmd.Run()
+    if err != nil {
+        return
+    }
+
     return
-}
-
-return
 }

--- a/internal/gopen/gopen.go
+++ b/internal/gopen/gopen.go
@@ -2,50 +2,50 @@
 package gopen
 
 import (
-    "errors"
-    "os"
-    "os/exec"
+	"errors"
+	"os"
+	"os/exec"
 
-    "github.com/wipdev-tech/gopen/internal/structs"
+	"github.com/wipdev-tech/gopen/internal/structs"
 )
 
 // Gopen uses the Config struct to find the path corresponding to targetAlias
 // and executes the editor command with the target path as the working
 // directory
 func Gopen(targetAlias string, config structs.Config) (err error) {
-    var targetPath string
-    for _, dirAlias := range config.DirAliases {
-        if targetAlias == dirAlias.Alias {
-            targetPath = dirAlias.Path
-            break
-        }
-    }
+	var targetPath string
+	for _, dirAlias := range config.DirAliases {
+		if targetAlias == dirAlias.Alias {
+			targetPath = dirAlias.Path
+			break
+		}
+	}
 
-    if targetPath == "" {
-        return errors.New("Invalid command or non-existent alias\nRun `gopen help` for info")
-    }
-    var cmd *exec.Cmd
-    editorCmd := config.EditorCmd
-    err = os.Chdir(targetPath)
-    if err != nil {
-        return
-    }
-    // Custom editor allows for the use of non-terminal based editors
-    // that need the path to the project as an argument
-    if config.CustomBehaviour {
-        cmd = exec.Command(editorCmd, targetPath)
-    } else {
-        cmd = exec.Command(editorCmd)
-    }
+	if targetPath == "" {
+		return errors.New("Invalid command or non-existent alias\nRun `gopen help` for info")
+	}
+	var cmd *exec.Cmd
+	editorCmd := config.EditorCmd
+	err = os.Chdir(targetPath)
+	if err != nil {
+		return
+	}
+	// Custom editor allows for the use of non-terminal based editors
+	// that need the path to the project as an argument
+	if config.CustomBehaviour {
+		cmd = exec.Command(editorCmd, targetPath)
+	} else {
+		cmd = exec.Command(editorCmd)
+	}
 
-    cmd.Stdin = os.Stdin
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
-    err = cmd.Run()
-    if err != nil {
-        return
-    }
+	err = cmd.Run()
+	if err != nil {
+		return
+	}
 
-    return
+	return
 }

--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -2,12 +2,12 @@
 package structs
 
 type Config struct {
-    EditorCmd       string     `json:"editorCmd"`
-    CustomBehaviour bool
-    DirAliases      []DirAlias `json:"aliases"`
+	EditorCmd       string `json:"editorCmd"`
+	CustomBehaviour bool
+	DirAliases      []DirAlias `json:"aliases"`
 }
 
 type DirAlias struct {
-    Alias string `json:"alias"`
-    Path  string `json:"path"`
+	Alias string `json:"alias"`
+	Path  string `json:"path"`
 }

--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -2,11 +2,12 @@
 package structs
 
 type Config struct {
-	EditorCmd  string     `json:"editorCmd"`
-	DirAliases []DirAlias `json:"aliases"`
+    EditorCmd       string     `json:"editorCmd"`
+    CustomBehaviour bool
+    DirAliases      []DirAlias `json:"aliases"`
 }
 
 type DirAlias struct {
-	Alias string `json:"alias"`
-	Path  string `json:"path"`
+    Alias string `json:"alias"`
+    Path  string `json:"path"`
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/wipdev-tech/gopen/internal/config"
 	"github.com/wipdev-tech/gopen/internal/diralias"
@@ -35,7 +36,10 @@ func main() {
 
 	case "remove", "r":
 		handleRemove()
-
+    case "migrate", "m":
+        handleMigrate()
+    case "custom", "c":
+        handleCustom()
 	default:
 		handleGopen()
 	}
@@ -132,6 +136,45 @@ func handleRemove() {
 	errFatal(err)
 }
 
+func handleMigrate() {
+    err := config.Migrate(configPath)
+    if err != nil {
+        errFatal(err)
+    }
+    fmt.Println("Successfully migrated config")
+}
+func handleCustom() {
+    
+    if len(os.Args) < 3 {
+        fmt.Println("Unexpected number of args: expected 2")
+    }
+
+    arg := strings.ToLower(os.Args[2])
+
+    if arg != "false" &&  arg != "true" {
+        err := fmt.Errorf("Error: expected argument true or false, got %v", arg)
+        errFatal(err)
+    }
+
+    custom := true
+
+    if arg == "false" {
+        custom = false
+    }
+    configObj, err := config.Read(configPath)
+    if err != nil {
+        errFatal(err)
+    }
+
+    configObj.CustomBehaviour = custom
+    err = config.Write(configObj, configPath)
+    if err != nil {
+        errFatal(err)
+    }
+
+    fmt.Printf("Successfully set custom behaviour to: %s\n", arg)
+    
+}
 func handleHelp() {
 	fmt.Print(`Gopen - a simple CLI to quick-start coding projects
 

--- a/main.go
+++ b/main.go
@@ -36,10 +36,10 @@ func main() {
 
 	case "remove", "r":
 		handleRemove()
-    case "migrate", "m":
-        handleMigrate()
-    case "custom", "c":
-        handleCustom()
+	case "migrate", "m":
+		handleMigrate()
+	case "custom", "c":
+		handleCustom()
 	default:
 		handleGopen()
 	}
@@ -137,43 +137,43 @@ func handleRemove() {
 }
 
 func handleMigrate() {
-    err := config.Migrate(configPath)
-    if err != nil {
-        errFatal(err)
-    }
-    fmt.Println("Successfully migrated config")
+	err := config.Migrate(configPath)
+	if err != nil {
+		errFatal(err)
+	}
+	fmt.Println("Successfully migrated config")
 }
 func handleCustom() {
-    
-    if len(os.Args) < 3 {
-        fmt.Println("Unexpected number of args: expected 2")
-    }
 
-    arg := strings.ToLower(os.Args[2])
+	if len(os.Args) < 3 {
+		fmt.Println("Unexpected number of args: expected 2")
+	}
 
-    if arg != "false" &&  arg != "true" {
-        err := fmt.Errorf("Error: expected argument true or false, got %v", arg)
-        errFatal(err)
-    }
+	arg := strings.ToLower(os.Args[2])
 
-    custom := true
+	if arg != "false" && arg != "true" {
+		err := fmt.Errorf("Error: expected argument true or false, got %v", arg)
+		errFatal(err)
+	}
 
-    if arg == "false" {
-        custom = false
-    }
-    configObj, err := config.Read(configPath)
-    if err != nil {
-        errFatal(err)
-    }
+	custom := true
 
-    configObj.CustomBehaviour = custom
-    err = config.Write(configObj, configPath)
-    if err != nil {
-        errFatal(err)
-    }
+	if arg == "false" {
+		custom = false
+	}
+	configObj, err := config.Read(configPath)
+	if err != nil {
+		errFatal(err)
+	}
 
-    fmt.Printf("Successfully set custom behaviour to: %s\n", arg)
-    
+	configObj.CustomBehaviour = custom
+	err = config.Write(configObj, configPath)
+	if err != nil {
+		errFatal(err)
+	}
+
+	fmt.Printf("Successfully set custom behaviour to: %s\n", arg)
+
 }
 func handleHelp() {
 	fmt.Print(`Gopen - a simple CLI to quick-start coding projects


### PR DESCRIPTION
By changing the custom behaviour gopen can support other editors or open nvim in netrw.
Add functionality to run a migration and to change the custom behaviour.
The default is set to false when running the migration which is the only way to overwrite the config file if it exists.