### PR TITLE
Fixes Incompatibility with other editor commands

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,15 +40,31 @@ func Init(configDir string, configPath string) (err error) {
 func Write(config structs.Config, configPath string) (err error) {
 	jsonFile, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return
+		return err
 	}
 
 	err = os.WriteFile(configPath, jsonFile, 0644)
 	if err != nil {
-		return
+		return err
 	}
 
-	return
+	return nil
+}
+
+// WriteV1 writes config to configPath (will OVERWRITE if file already exists)
+// This is used for testing the migration of v1 config files to v2 config files
+func WriteV1(config structs.ConfigV1, configPath string) (err error) {
+	jsonFile, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(configPath, jsonFile, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Read reads the configPath file and returns a Config struct
@@ -64,4 +80,41 @@ func Read(configPath string) (config structs.Config, err error) {
 	}
 
 	return
+}
+
+// ReadV1 reads the configPath file and returns a ConfigV1 struct
+// This is used for migrating v1 config files to v2 config files
+func ReadV1(configPath string) (config structs.ConfigV1, err error) {
+	f, err := os.ReadFile(configPath)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(f, &config)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// Migrate migrates a v1 config file to a v2 config file
+func Migrate(configPath string) error {
+	originalConfig, err := ReadV1(configPath)
+	if err != nil {
+		return err
+	}
+
+	var newConfig = &structs.Config{
+		EditorCmd:       originalConfig.EditorCmd,
+		CustomBehaviour: false,
+		DirAliases:      originalConfig.DirAliases,
+	}
+
+	err = Write(*newConfig, configPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/diralias/diralias.go
+++ b/internal/diralias/diralias.go
@@ -8,7 +8,7 @@ import (
 	"github.com/wipdev-tech/gopen/internal/structs"
 )
 
-// listDirAliases pretty-prints each alias and its corresponding path
+// List pretty-prints each alias and its corresponding path
 func List(config structs.Config) (fmtAliases []string) {
 	var width int
 	for _, dirAlias := range config.DirAliases {
@@ -32,7 +32,9 @@ func List(config structs.Config) (fmtAliases []string) {
 func Add(config structs.Config, alias string, path string) (newConfig structs.Config, err error) {
 	newConfig = config
 
-	reserved := []string{"a", "alias", "e", "editor", "h", "help", "i", "init"}
+	// Check if alias is reserved
+	// Prevents aliases from matching Gopen commands
+	reserved := []string{"a", "alias", "e", "editor", "h", "help", "i", "init", "custom", "c", "m", "migrate", "r", "remove"}
 	for _, r := range reserved {
 		if r == alias {
 			err = fmt.Errorf("Error: `%v` is reserved and can't be used as an alias", alias)

--- a/internal/gopen/gopen.go
+++ b/internal/gopen/gopen.go
@@ -24,14 +24,21 @@ func Gopen(targetAlias string, config structs.Config) (err error) {
 	if targetPath == "" {
 		return errors.New("Invalid command or non-existent alias\nRun `gopen help` for info")
 	}
-
+	var cmd *exec.Cmd
 	editorCmd := config.EditorCmd
 	err = os.Chdir(targetPath)
 	if err != nil {
 		return
 	}
 
-	cmd := exec.Command(editorCmd)
+	// The new behaviour is to open the editor in the current directory to allow for non-terminal editors to be used
+	// If the user wants to use the old behaviour, they can set the customBehaviour flag to true in the config file
+	if config.CustomBehaviour {
+		cmd = exec.Command(editorCmd)
+	} else {
+		cmd = exec.Command(editorCmd, targetPath)
+	}
+
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -1,11 +1,19 @@
 // Package structs simply contains struct types to be used by other packages.
 package structs
 
+// Config is the struct for the v2 config file
 type Config struct {
+	EditorCmd       string     `json:"editorCmd"`
+	CustomBehaviour bool       `json:"customBehaviour"`
+	DirAliases      []DirAlias `json:"aliases"`
+}
+
+// ConfigV1 is the struct for the v1 config file
+// It is used for migrating v1 config files to v2 config files and testing
+type ConfigV1 struct {
 	EditorCmd  string     `json:"editorCmd"`
 	DirAliases []DirAlias `json:"aliases"`
 }
-
 type DirAlias struct {
 	Alias string `json:"alias"`
 	Path  string `json:"path"`

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/wipdev-tech/gopen/internal/config"
 	"github.com/wipdev-tech/gopen/internal/diralias"
@@ -35,7 +36,10 @@ func main() {
 
 	case "remove", "r":
 		handleRemove()
-
+	case "migrate", "m":
+		handleMigrate()
+	case "custom", "c":
+		handleCustom()
 	default:
 		handleGopen()
 	}
@@ -132,6 +136,45 @@ func handleRemove() {
 	errFatal(err)
 }
 
+func handleMigrate() {
+	err := config.Migrate(configPath)
+	if err != nil {
+		errFatal(err)
+	}
+	fmt.Println("Successfully migrated config")
+}
+func handleCustom() {
+
+	if len(os.Args) < 3 {
+		fmt.Println("Unexpected number of args: expected 2")
+	}
+
+	arg := strings.ToLower(os.Args[2])
+
+	if arg != "false" && arg != "true" {
+		err := fmt.Errorf("Error: expected argument true or false, got %v", arg)
+		errFatal(err)
+	}
+
+	custom := true
+
+	if arg == "false" {
+		custom = false
+	}
+	configObj, err := config.Read(configPath)
+	if err != nil {
+		errFatal(err)
+	}
+
+	configObj.CustomBehaviour = custom
+	err = config.Write(configObj, configPath)
+	if err != nil {
+		errFatal(err)
+	}
+
+	fmt.Printf("Successfully set custom behaviour to: %s\n", arg)
+
+}
 func handleHelp() {
 	fmt.Print(`Gopen - a simple CLI to quick-start coding projects
 


### PR DESCRIPTION
Created a new config with custom behaviour property defaulting to false
Read from custom behaviour. If it is true, revert to old behaviour that opens a new blank buffer.
Made tests.
Made a migration method