### PR TITLE
feat: custom editor behaviour

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -187,6 +187,7 @@ func TestWriteConfig(t *testing.T) {
 	}
 	expectedOutput := `{
   "editorCmd": "vim",
+  "customBehaviour": false,
   "aliases": [
     {
       "alias": "docs",

--- a/internal/diralias/diralias.go
+++ b/internal/diralias/diralias.go
@@ -41,10 +41,15 @@ func Add(config structs.Config, alias string, path string) (newConfig structs.Co
 		}
 	}
 
-    newPath, err := filepath.Abs(path)
-    if err != nil {
-        return
-    }
+	// If the path is ".", then we want to use the current directory
+	// instead of the literal "."
+	if path == "." {
+		path = "./"
+	}
+	newPath, err := filepath.Abs(path)
+	if err != nil {
+		return
+	}
 
 	newDirAlias := structs.DirAlias{Alias: alias, Path: newPath}
 

--- a/internal/gopen/gopen.go
+++ b/internal/gopen/gopen.go
@@ -31,7 +31,14 @@ func Gopen(targetAlias string, config structs.Config) (err error) {
 		return
 	}
 
-	cmd := exec.Command(editorCmd)
+	var cmd *exec.Cmd
+	// CustomBehaviour lets the user open the target path in a new buffer
+	if config.CustomBehaviour {
+		cmd = exec.Command(editorCmd)
+	} else {
+		cmd = exec.Command(editorCmd, targetPath)
+	}
+
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -2,8 +2,9 @@
 package structs
 
 type Config struct {
-	EditorCmd  string     `json:"editorCmd"`
-	DirAliases []DirAlias `json:"aliases"`
+	EditorCmd       string     `json:"editorCmd"`
+	CustomBehaviour bool       `json:"customBehaviour"`
+	DirAliases      []DirAlias `json:"aliases"`
 }
 
 type DirAlias struct {

--- a/main.go
+++ b/main.go
@@ -35,7 +35,8 @@ func main() {
 
 	case "remove", "r":
 		handleRemove()
-
+	case "custom", "c":
+		handleCustom()
 	default:
 		handleGopen()
 	}
@@ -131,6 +132,28 @@ func handleRemove() {
 	err = config.Write(newConfig, configPath)
 	errFatal(err)
 }
+func handleCustom() {
+	configObj, err := config.Read(configPath)
+	errFatal(err)
+
+	switch len(os.Args) {
+	case 2:
+		fmt.Printf("Custom behaviour is set to :%v\n", configObj.CustomBehaviour)
+	case 3:
+		if os.Args[2] == "true" {
+			configObj.CustomBehaviour = true
+		} else if os.Args[2] == "false" {
+			configObj.CustomBehaviour = false
+		} else {
+			fmt.Println("Invalid argument, expected 'true' or 'false'")
+		}
+		err = config.Write(configObj, configPath)
+		errFatal(err)
+	default:
+		fmt.Println("Invalid number of arguments")
+	}
+
+}
 
 func handleHelp() {
 	fmt.Print(`Gopen - a simple CLI to quick-start coding projects
@@ -153,6 +176,8 @@ Can be abbreviated by the first letter ('gopen i' == 'gopen init')
     alias foo bar     Assign to alias 'foo' the path 'bar'
 
     remove foo        Remove alias 'foo' from the config
+    custom            Get custom behaviour
+    custom bool       Set custom behaviour to true or false
 
     help              Print this help message
 


### PR DESCRIPTION
fixes #1 

Made a setting called custom behaviour that defaults to false.
Custom behaviour set to true: opens up directory in new buffer, else opens in netrw or editor of choice.
Added a command to get custom behaviour and change it. No args gets custom behaviour configuration
args are true or false

Updated help command.